### PR TITLE
Update: My Proposal Endpoint to Include Project Title

### DIFF
--- a/freelance_marketplace_backend/Models/Dtos/ProposalDto.cs
+++ b/freelance_marketplace_backend/Models/Dtos/ProposalDto.cs
@@ -1,23 +1,23 @@
 ﻿namespace freelance_marketplace_backend.Models.Dtos
 {
-	// DTO for displaying basic details about each proposal
-	public class ProposalDto
-	{
-		public int ProposalId { get; set; } // ID of the proposal
+    // DTO for displaying basic details about each proposal
+    public class ProposalDto
+    {
+        public int ProposalId { get; set; } // ID of the proposal
 
-		public int ProjectId { get; set; } // ID of the project associated with this proposal
-		public string FreelancerId { get; set; } = null!; // ID of the freelancer who submitted the proposal
-		public string FreelancerName { get; set; } = null!; // Name of the freelancer who submitted the proposal
+        public int ProjectId { get; set; } // ID of the project associated with this proposal
+        public string FreelancerId { get; set; } = null!; // ID of the freelancer who submitted the proposal
+        public string FreelancerName { get; set; } = null!; // Name of the freelancer who submitted the proposal
+        public string ProjectTitle { get; set; } // Title of the project associated with this proposal
+        public decimal ProposedAmount { get; set; } // Amount proposed by the freelancer
 
-		public decimal ProposedAmount { get; set; } // Amount proposed by the freelancer
+        public DateOnly Deadline { get; set; } // Deadline suggested by the freelancer for completing the project
 
-		public DateOnly Deadline { get; set; } // Deadline suggested by the freelancer for completing the project
+        public string CoverLetter { get; set; } = null!; // Cover letter or description from the freelancer
 
-		public string CoverLetter { get; set; } = null!; // Cover letter or description from the freelancer
+        public string Status { get; set; } = null!; // Status of the proposal (e.g., Pending, Accepted, Rejected)
 
-		public string Status { get; set; } = null!; // Status of the proposal (e.g., Pending, Accepted, Rejected)
-
-		public string ProfilePictureUrl { get; set; } = null!; // URL of the freelancer's profile picture
-		public DateTime CreatedAt { get; set; } // Date and time when the proposal was created
-	}
+        public string ProfilePictureUrl { get; set; } = null!; // URL of the freelancer's profile picture
+        public DateTime CreatedAt { get; set; } // Date and time when the proposal was created
+    }
 }

--- a/freelance_marketplace_backend/Services/ProposalService .cs
+++ b/freelance_marketplace_backend/Services/ProposalService .cs
@@ -79,6 +79,7 @@ namespace freelance_marketplace_backend.Services
             {
                 var proposals = await _context
                     .Proposals.Include(p => p.Freelancer)
+                    .Include(p => p.Project) 
                     .Where(p =>
                         p.FreelancerId == freelancerId
                         && (p.IsDeleted == null || p.IsDeleted == false)
@@ -90,6 +91,7 @@ namespace freelance_marketplace_backend.Services
                 {
                     ProposalId = p.ProposalId,
                     ProjectId = p.ProjectId,
+                    ProjectTitle = p.Project?.Title ?? "Unknown",
                     FreelancerId = p.FreelancerId,
                     FreelancerName = p.Freelancer.Name,
                     ProposedAmount = p.ProposedAmount,


### PR DESCRIPTION
Update: My Proposal Endpoint to Include Project Title

This PR enhances the GetMyProposals endpoint to return the associated Project Title for each proposal. This allows the frontend (e.g., MyProposalsComponent) to display more meaningful proposal data to freelancers.

Changes Made: 

Updated the backend ProposalService to include Project.Title in the ProposalDto.
Adjusted the ProposalDto model to include a new ProjectTitle property.
