### PR TITLE
Fix User Cache Refresh After Project Actions

### DIFF
--- a/freelance_marketplace_backend/Controllers/ClientProjectController.cs
+++ b/freelance_marketplace_backend/Controllers/ClientProjectController.cs
@@ -58,9 +58,12 @@ namespace freelance_marketplace_backend.Controllers
             var result = await _clientProjectService.MarkProjectAsCompleted(projectId);
             if (result)
             {
-                // clear cash
+                // clear cash from AvailableProjects
                 var all_avalible_projects_cacheKey = "AvailableProjects";
                 await _cache.RemoveAsync(all_avalible_projects_cacheKey);
+
+                
+
                 return Ok(new { message = "Project marked as completed successfully." });
             }
             return BadRequest(new { message = "Failed to mark the project as completed." });

--- a/freelance_marketplace_backend/Controllers/ProjectsController.cs
+++ b/freelance_marketplace_backend/Controllers/ProjectsController.cs
@@ -150,10 +150,13 @@ namespace freelance_marketplace_backend.Controllers
                 // Invalidate the cache for the project after assignment
                 await _cache.RemoveAsync($"project:{projectId}");
 
-                // clear cash from avalible projects
+                // clear cash to avalible projects
                 var all_avalible_projects_cacheKey = "AvailableProjects";
                 await _cache.RemoveAsync(all_avalible_projects_cacheKey);
                 var message = $"Congratulations! Your Proposal has been accepted for the project Number: {projectId}";
+                // clear cash to user balance
+                var cacheKey = $"UserProfile_{uid}";
+                await _cache.RemoveAsync(cacheKey);
 
                 await _twilioService.SendSmsAsync(model.FreelancerPhoneNumber, message);
                 // Return the updated project details

--- a/freelance_marketplace_backend/Data/Repositories/ClientProjectRepository.cs
+++ b/freelance_marketplace_backend/Data/Repositories/ClientProjectRepository.cs
@@ -1,5 +1,6 @@
 ﻿using freelance_marketplace_backend.Models.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace freelance_marketplace_backend.Data.Repositories
 {
@@ -7,10 +8,11 @@ namespace freelance_marketplace_backend.Data.Repositories
     {
 
         private readonly FreelancingPlatformContext _context;
-
-        public ClientProjectRepository(FreelancingPlatformContext context)
+        private readonly IDistributedCache _cache;
+        public ClientProjectRepository(FreelancingPlatformContext context, IDistributedCache cache)
         {
             _context = context;
+            _cache = cache;
         }
 
         public async Task<List<Project>> GetApprovedProjectsForClientAsync(string clientId)
@@ -35,7 +37,9 @@ namespace freelance_marketplace_backend.Data.Repositories
             _context.Projects.Update(project);
             _context.Users.Update(freelancer);
             await _context.SaveChangesAsync();
-
+            // clear cash to user balance
+            var usercacheKey = $"UserProfile_{project.FreelancerId}";
+            await _cache.RemoveAsync(usercacheKey);
             return true;
         }
 

--- a/freelance_marketplace_backend/Services/ClientProjectService.cs
+++ b/freelance_marketplace_backend/Services/ClientProjectService.cs
@@ -72,6 +72,8 @@ namespace freelance_marketplace_backend.Services
                 {
                     string cacheKey = $"approved_projects_{userId}";
                     await _cache.RemoveAsync(cacheKey); // Clear cache for this user
+
+                   
                 }
             }
             return success;


### PR DESCRIPTION
### Description:
Fixes backend-side caching issues by clearing the cached user profile after key actions like project completion or assignment.

### Changes Made:

✅ Invalidate user cache in Redis (or memory cache) after:

- Marking a project as completed.

- Assigning a project to a freelancer.

✅ Ensured that /api/Auth/users/{userId} always returns fresh data post-project update.

### Result:
Clients get the latest user profile (e.g., updated balance) right after backend actions, without requiring a full logout.